### PR TITLE
DOCTYPE declaration issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 }
 
 group = 'com.github.eerohele'
-version = '0.1.3'
+version = '0.1.4-doctype-fix'
 
 test {
     systemProperty 'examples.dir', new File(projectDir, 'examples')

--- a/src/main/groovy/com/github/eerohele/SaxonXsltTask.groovy
+++ b/src/main/groovy/com/github/eerohele/SaxonXsltTask.groovy
@@ -71,18 +71,18 @@ class SaxonXsltTask extends DefaultTask {
     // Read output file extension from the <xsl:output> element of the
     // stylesheet.
     private String getDefaultOutputExtension(File stylesheet) {
-        String method = new XmlSlurper()
-            // (2016-06-27) charlescrichton: 
-            // Issue: Error when running XSLT containing DOCTYPE: 'DOCTYPE is disallowed when the feature "http://apache.org/xml/features/disallow-doctype-decl" set to true.'
-            // Using the fix from http://stackoverflow.com/a/30754000 
-            .setFeature("http://apache.org/xml/features/disallow-doctype-decl", false) // http://stackoverflow.com/a/30754000
-            
-            .setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false); // http://stackoverflow.com/a/30754000
-            
-            .parse(stylesheet)
-            .declareNamespace(xsl: 'http://www.w3.org/1999/XSL/Transform')
-            .output
-            .@method
+        
+        XmlSlurper parser = new XmlSlurper()
+        // (2016-06-27) charlescrichton: 
+        // Issue: Error when running XSLT containing DOCTYPE: 'DOCTYPE is disallowed when the feature "http://apache.org/xml/features/disallow-doctype-decl" set to true.'
+        // Using the fix from http://stackoverflow.com/a/30754000 
+        parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)  
+        parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)             
+        String method = parser
+                            .parse(stylesheet)
+                            .declareNamespace(xsl: 'http://www.w3.org/1999/XSL/Transform')
+                            .output
+                            .@method
 
         return method ? method : 'xml'
     }

--- a/src/main/groovy/com/github/eerohele/SaxonXsltTask.groovy
+++ b/src/main/groovy/com/github/eerohele/SaxonXsltTask.groovy
@@ -72,6 +72,13 @@ class SaxonXsltTask extends DefaultTask {
     // stylesheet.
     private String getDefaultOutputExtension(File stylesheet) {
         String method = new XmlSlurper()
+            // (2016-06-27) charlescrichton: 
+            // Issue: Error when running XSLT containing DOCTYPE: 'DOCTYPE is disallowed when the feature "http://apache.org/xml/features/disallow-doctype-decl" set to true.'
+            // Using the fix from http://stackoverflow.com/a/30754000 
+            .setFeature("http://apache.org/xml/features/disallow-doctype-decl", false) // http://stackoverflow.com/a/30754000
+            
+            .setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false); // http://stackoverflow.com/a/30754000
+            
             .parse(stylesheet)
             .declareNamespace(xsl: 'http://www.w3.org/1999/XSL/Transform')
             .output


### PR DESCRIPTION
I have added a small fix to enable XSLTs with DOCTYPE declarations in them to work in `src/main/groovy/com/github/eerohele/SaxonXsltTask.groovy`.

Please consider pulling this into your code.

I have, locally to me, called this version `version = '0.1.4-doctype-fix'`. You will want to pick your own version number. 

Thanks for providing this plugin. Very useful. 
