### PR TITLE
Handle missing stylesheets

### DIFF
--- a/src/main/groovy/com/github/eerohele/SaxonXsltTask.groovy
+++ b/src/main/groovy/com/github/eerohele/SaxonXsltTask.groovy
@@ -135,10 +135,16 @@ class SaxonXsltTask extends DefaultTask {
 
     void stylesheet(Object stylesheet) {
         this.options.stylesheet = project.file(stylesheet)
-
-        this.xslt = this.xmlSlurper
-                .parse(stylesheet)
-                .declareNamespace(xsl: XSLT_NAMESPACE)
+        if (this.options.stylesheet.exists()) {
+            try {
+                this.xslt = this.xmlSlurper
+                        .parse(stylesheet)
+                        .declareNamespace(xsl: XSLT_NAMESPACE)
+            } catch (Exception ex) {
+                logger.warn("Failed to parse: ${this.options.stylesheet}")
+                logger.warn("  ${ex.getMessage()}")
+            }
+        }
     }
 
     void stylesheetSaxParser(String parser) {
@@ -655,12 +661,20 @@ class SaxonXsltTask extends DefaultTask {
     protected FileCollection getIncludedStylesheets(File stylesheet, FileCollection stylesheets = project.files()) {
         if (stylesheet == null) return stylesheets
 
-        GPathResult xslt = this.xmlSlurper.parse(stylesheet).declareNamespace(xsl: XSLT_NAMESPACE)
-
-        project.files(stylesheet) + (xslt.include + xslt.import).inject(stylesheets) { acc, i ->
-            URI href = resolveUri(i.@href[0].toString())
-            URI uri = stylesheet.toURI().resolve(href)
-            acc + getIncludedStylesheets(new File(uri), acc)
+        try {
+            GPathResult xslt = this.xmlSlurper.parse(stylesheet).declareNamespace(xsl: XSLT_NAMESPACE)
+    
+            project.files(stylesheet) + (xslt.include + xslt.import).inject(stylesheets) { acc, i ->
+                URI href = resolveUri(i.@href[0].toString())
+                URI uri = stylesheet.toURI().resolve(href)
+                acc + getIncludedStylesheets(new File(uri), acc)
+            }
+        } catch (FileNotFoundException ex) {
+            return stylesheets
+        } catch (Exception ex) {
+            logger.warn("Failed to parse: ${stylesheet}")
+            logger.warn("  ${ex.getMessage()}")
+            return stylesheets
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug where the task is too aggressive about parsing stylesheets during the configuration phase.

My use case is a complex build ([xslTNG](https://github.com/ndw/xslTNG)) where some stylesheets are downloaded during the build. Attempting to use these stylesheets with `SaxonXsltTask` always fails because the stylesheets don't exist during the configuration phase.

I've tried to make the changes minimal.

(I'm going to publish my fork of this project in order to quickly unblock myself, but I'll happily switch back to the "official" release if you can apply this, or a similar, patch.)