### PR TITLE
extract files to dedicated properties to mark them with PathSensivity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation 'net.sf.saxon:Saxon-HE:9.8.0-14'
     implementation 'xml-resolver:xml-resolver:1.2'
 
-    testCompile('org.spockframework:spock-core:1.3-groovy-2.5') {
+    testImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
         exclude group: 'org.codehaus.groovy'
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.warning.mode=fail

--- a/src/main/groovy/com/github/eerohele/SaxonXsltTask.groovy
+++ b/src/main/groovy/com/github/eerohele/SaxonXsltTask.groovy
@@ -4,7 +4,12 @@ import groovy.util.slurpersupport.GPathResult
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFiles
@@ -26,22 +31,29 @@ class SaxonXsltTask extends DefaultTask {
     protected static final String PERIOD = '.'
     protected static final String XSLT_NAMESPACE = 'http://www.w3.org/1999/XSL/Transform'
 
-    protected final List<String> defaultArguments = ['-quit:off'].asImmutable()
+    protected static final List<String> DEFAULT_ARGUMENTS = ['-quit:off'].asImmutable()
 
-    protected final Map<String, Object> options = [output: project.buildDir]
+    private Object inputFiles
+    private File catalogFile
+    private File stylesheetFile
+    private File outputDir = project.buildDir
+
+    protected final Map<String, Object> options = [:]
 
     protected final Map<String, Object> pluginOptions = [outputDirectoryLayout: 'flat']
 
     @Classpath
+    @InputFiles
     final ConfigurableFileCollection classpath
 
-    protected final Map<String, String> advancedOptions = [:]
+    protected final Map<String, Object> advancedOptions = [:]
 
     protected Map<String, String> stylesheetParams = [:]
 
     private final XmlSlurper xmlSlurper = new XmlSlurper()
     private GPathResult xslt
     private Catalog xmlCatalog
+
     private final CatalogManager catalogManager = new CatalogManager()
 
     // Saxon command-line options take 'on' and 'off', but it's best to let the
@@ -80,9 +92,9 @@ class SaxonXsltTask extends DefaultTask {
     }
 
     void catalog(Object catalog) {
-        this.options.catalog = project.file(catalog)
+        this.catalogFile = project.file(catalog)
 
-        URI catalogs = this.options.catalog.toURI()
+        URI catalogs = this.catalogFile.toURI()
         catalogManager.setCatalogFiles(catalogs.toString())
         xmlCatalog = new Catalog(catalogManager)
         xmlCatalog.setupReaders()
@@ -114,7 +126,7 @@ class SaxonXsltTask extends DefaultTask {
     }
 
     void input(Object input) {
-        this.options.input = input
+        this.inputFiles = input
     }
 
     void lineNumbers(Object lineNumbers) {
@@ -126,7 +138,7 @@ class SaxonXsltTask extends DefaultTask {
     }
 
     void output(Object output) {
-        this.options.output = project.file(output)
+        this.outputDir = project.file(output)
     }
 
     void sourceSaxParser(String parser) {
@@ -135,14 +147,14 @@ class SaxonXsltTask extends DefaultTask {
 
     @SuppressWarnings('CatchException')
     void stylesheet(Object stylesheet) {
-        this.options.stylesheet = project.file(stylesheet)
-        if (this.options.stylesheet.exists()) {
+        this.stylesheetFile = project.file(stylesheet)
+        if (this.stylesheetFile.exists()) {
             try {
                 this.xslt = this.xmlSlurper
-                        .parse(stylesheet)
+                        .parse(this.stylesheetFile)
                         .declareNamespace(xsl: XSLT_NAMESPACE)
             } catch (Exception ex) {
-                logger.warn("Failed to parse: ${this.options.stylesheet}")
+                logger.warn("Failed to parse: ${this.stylesheetFile}")
                 logger.warn("  ${ex.getMessage()}")
             }
         }
@@ -175,459 +187,459 @@ class SaxonXsltTask extends DefaultTask {
     // START ADVANCED OPTIONS
 
     void allowExternalFunctions(Boolean x) {
-        this.advancedOptions['allow-external-functions'] = x;
+        this.advancedOptions['allow-external-functions'] = x
     }
 
     void allowMultithreading(Boolean x) {
-        this.advancedOptions['allow-multithreading'] = x;
+        this.advancedOptions['allow-multithreading'] = x
     }
 
     void allowOldJavaURIFormat(Boolean x) {
-        this.advancedOptions['allow-old-java-uri-format'] = x;
+        this.advancedOptions['allow-old-java-uri-format'] = x
     }
 
     void allowSyntaxExtensions(Boolean x) {
-        this.advancedOptions.allowSyntaxExtensions = x;
+        this.advancedOptions.allowSyntaxExtensions = x
     }
 
     void assertionsCanSeeComments(Boolean x) {
-        this.advancedOptions.assertionsCanSeeComments = x;
+        this.advancedOptions.assertionsCanSeeComments = x
     }
 
     void collationUriResolver(Object x) {
-        this.advancedOptions['collation-uri-resolver'] = x;
+        this.advancedOptions['collation-uri-resolver'] = x
     }
 
     void collationUriResolverClass(Object x) {
-        this.advancedOptions['collation-uri-resolver-class'] = x;
+        this.advancedOptions['collation-uri-resolver-class'] = x
     }
 
     void collectionFinder(Object x) {
-        this.advancedOptions['collection-finder'] = x;
+        this.advancedOptions['collection-finder'] = x
     }
 
     void collectionFinderClass(Object x) {
-        this.advancedOptions['collection-finder-class'] = x;
+        this.advancedOptions['collection-finder-class'] = x
     }
 
     void collectionUriResolver(Object x) {
-        this.advancedOptions['collection-uri-resolver'] = x;
+        this.advancedOptions['collection-uri-resolver'] = x
     }
 
     void collectionUriResolverClass(Object x) {
-        this.advancedOptions['collection-uri-resolver-class'] = x;
+        this.advancedOptions['collection-uri-resolver-class'] = x
     }
 
     void compileWithTracing(Boolean x) {
-        this.advancedOptions.with = x;
+        this.advancedOptions.with = x
     }
 
     void configuration(Object x) {
-        this.advancedOptions.configuration = x;
+        this.advancedOptions.configuration = x
     }
 
     void configurationFile(Object x) {
-        this.advancedOptions['configuration-file'] = x;
+        this.advancedOptions['configuration-file'] = x
     }
 
     void debugByteCode(Object x) {
-        this.advancedOptions.debugByteCode = x;
+        this.advancedOptions.debugByteCode = x
     }
 
     void debugByteCodeDir(Object x) {
-        this.advancedOptions.debugByteCodeDir = x;
+        this.advancedOptions.debugByteCodeDir = x
     }
 
     void defaultCollation(Object x) {
-        this.advancedOptions.defaultCollation = x;
+        this.advancedOptions.defaultCollation = x
     }
 
     void defaultCollection(Object x) {
-        this.advancedOptions.defaultCollection = x;
+        this.advancedOptions.defaultCollection = x
     }
 
     void defaultCountry(Object x) {
-        this.advancedOptions.defaultCountry = x;
+        this.advancedOptions.defaultCountry = x
     }
 
     void defaultLanguage(Object x) {
-        this.advancedOptions.defaultLanguage = x;
+        this.advancedOptions.defaultLanguage = x
     }
 
     void defaultRegexEngine(Object x) {
-        this.advancedOptions.defaultRegexEngine = x;
+        this.advancedOptions.defaultRegexEngine = x
     }
 
     void disableXslEvaluate(Boolean x) {
-        this.advancedOptions.disableXslEvaluate = x;
+        this.advancedOptions.disableXslEvaluate = x
     }
 
     void displayByteCode(Boolean x) {
-        this.advancedOptions.displayByteCode = x;
+        this.advancedOptions.displayByteCode = x
     }
 
     void validation(Object x) {
-        this.advancedOptions.validation = x;
+        this.advancedOptions.validation = x
     }
 
     void dtdValidationRecoverable(Object x) {
-        this.advancedOptions['dtd-validation-recoverable'] = x;
+        this.advancedOptions['dtd-validation-recoverable'] = x
     }
 
     void eagerEvaluation(Object x) {
-        this.advancedOptions.eagerEvaluation = x;
+        this.advancedOptions.eagerEvaluation = x
     }
 
     void entityResolverClass(Object x) {
-        this.advancedOptions.entityResolverClass = x;
+        this.advancedOptions.entityResolverClass = x
     }
 
     void environmentVariableResolver(Object x) {
-        this.advancedOptions.environmentVariableResolver = x;
+        this.advancedOptions.environmentVariableResolver = x
     }
 
     void environmentVariableResolverClass(Object x) {
-        this.advancedOptions.environmentVariableResolverClass = x;
+        this.advancedOptions.environmentVariableResolverClass = x
     }
 
     void errorListenerClass(Object x) {
-        this.advancedOptions.errorListenerClass = x;
+        this.advancedOptions.errorListenerClass = x
     }
 
     void expathFileDeleteTemporaryFiles(Object x) {
-        this.advancedOptions.expathFileDeleteTemporaryFiles = x;
+        this.advancedOptions.expathFileDeleteTemporaryFiles = x
     }
 
     void generateByteCode(Object x) {
-        this.advancedOptions.generateByteCode = x;
+        this.advancedOptions.generateByteCode = x
     }
 
     void ignoreSAXSourceParser(Object x) {
-        this.advancedOptions.ignoreSAXSourceParser = x;
+        this.advancedOptions.ignoreSAXSourceParser = x
     }
 
     void implicitSchemaImports(Object x) {
-        this.advancedOptions.implicitSchemaImports = x;
+        this.advancedOptions.implicitSchemaImports = x
     }
 
     void lazyConstructionMode(Object x) {
-        this.advancedOptions.lazyConstructionMode = x;
+        this.advancedOptions.lazyConstructionMode = x
     }
 
     void licenseFileLocation(Object x) {
-        this.advancedOptions.licenseFileLocation = x;
+        this.advancedOptions.licenseFileLocation = x
     }
 
     void markDefaultedAttributes(Object x) {
-        this.advancedOptions.markDefaultedAttributes = x;
+        this.advancedOptions.markDefaultedAttributes = x
     }
 
     void maxCompiledClasses(Object x) {
-        this.advancedOptions.maxCompiledClasses = x;
+        this.advancedOptions.maxCompiledClasses = x
     }
 
     void messageEmitterClass(Object x) {
-        this.advancedOptions.messageEmitterClass = x;
+        this.advancedOptions.messageEmitterClass = x
     }
 
     void moduleURIResolver(Object x) {
-        this.advancedOptions.moduleURIResolver = x;
+        this.advancedOptions.moduleURIResolver = x
     }
 
     void moduleURIResolverClass(Object x) {
-        this.advancedOptions.moduleURIResolverClass = x;
+        this.advancedOptions.moduleURIResolverClass = x
     }
 
     void monitorHotSpotByteCode(Object x) {
-        this.advancedOptions.monitorHotSpotByteCode = x;
+        this.advancedOptions.monitorHotSpotByteCode = x
     }
 
     void multipleSchemaImports(Object x) {
-        this.advancedOptions.multipleSchemaImports = x;
+        this.advancedOptions.multipleSchemaImports = x
     }
 
     void namePool(Object x) {
-        this.advancedOptions.namePool = x;
+        this.advancedOptions.namePool = x
     }
 
     void occurrenceLimits(Object x) {
-        this.advancedOptions.occurrenceLimits = x;
+        this.advancedOptions.occurrenceLimits = x
     }
 
     void optimizationLevel(Object x) {
-        this.advancedOptions.optimizationLevel = x;
+        this.advancedOptions.optimizationLevel = x
     }
 
     void outputURIResolver(Object x) {
-        this.advancedOptions.outputURIResolver = x;
+        this.advancedOptions.outputURIResolver = x
     }
 
     void outputURIResolverClass(Object x) {
-        this.advancedOptions.outputURIResolverClass = x;
+        this.advancedOptions.outputURIResolverClass = x
     }
 
     void parserFeature(Object x) {
-        this.advancedOptions.parserFeature = x;
+        this.advancedOptions.parserFeature = x
     }
 
     void parserProperty(Object x) {
-        this.advancedOptions.parserProperty = x;
+        this.advancedOptions.parserProperty = x
     }
 
     void preEvaluateDocFunction(Object x) {
-        this.advancedOptions.preEvaluateDocFunction = x;
+        this.advancedOptions.preEvaluateDocFunction = x
     }
 
     void preferJaxpParser(Object x) {
-        this.advancedOptions.preferJaxpParser = x;
+        this.advancedOptions.preferJaxpParser = x
     }
 
     void recognizeUriQueryParameters(Object x) {
-        this.advancedOptions['recognize-uri-query-parameters'] = x;
+        this.advancedOptions['recognize-uri-query-parameters'] = x
     }
 
     void recoveryPolicy(Object x) {
-        this.advancedOptions.recoveryPolicy = x;
+        this.advancedOptions.recoveryPolicy = x
     }
 
     void recoveryPolicyName(Object x) {
-        this.advancedOptions.recoveryPolicyName = x;
+        this.advancedOptions.recoveryPolicyName = x
     }
 
     void resultDocumentThreads(Object x) {
-        this.advancedOptions.resultDocumentThreads = x;
+        this.advancedOptions.resultDocumentThreads = x
     }
 
     void retainDtdAttributeTypes(Object x) {
-        this.advancedOptions['retain-dtd-attribute-types'] = x;
+        this.advancedOptions['retain-dtd-attribute-types'] = x
     }
 
     void schemaURIResolver(Object x) {
-        this.advancedOptions.schemaURIResolver = x;
+        this.advancedOptions.schemaURIResolver = x
     }
 
     void schemaURIResolverClass(Object x) {
-        this.advancedOptions.schemaURIResolverClass = x;
+        this.advancedOptions.schemaURIResolverClass = x
     }
 
     void schemaValidation(Object x) {
-        this.advancedOptions['schema-validation'] = x;
+        this.advancedOptions['schema-validation'] = x
     }
 
     void schemaValidationMode(Object x) {
-        this.advancedOptions['schema-validation-mode'] = x;
+        this.advancedOptions['schema-validation-mode'] = x
     }
 
     void serializerFactoryClass(Object x) {
-        this.advancedOptions.serializerFactoryClass = x;
+        this.advancedOptions.serializerFactoryClass = x
     }
 
     void sourceParserClass(Object x) {
-        this.advancedOptions.sourceParserClass = x;
+        this.advancedOptions.sourceParserClass = x
     }
 
     void sourceResolverClass(Object x) {
-        this.advancedOptions.sourceResolverClass = x;
+        this.advancedOptions.sourceResolverClass = x
     }
 
     void stableCollectionUri(Object x) {
-        this.advancedOptions.stableCollectionUri = x;
+        this.advancedOptions.stableCollectionUri = x
     }
 
     void stableUnparsedText(Object x) {
-        this.advancedOptions.stableUnparsedText = x;
+        this.advancedOptions.stableUnparsedText = x
     }
 
     void standardErrorOutputFile(Object x) {
-        this.advancedOptions.standardErrorOutputFile = x;
+        this.advancedOptions.standardErrorOutputFile = x
     }
 
     void streamability(Object x) {
-        this.advancedOptions.streamability = x;
+        this.advancedOptions.streamability = x
     }
 
     void strictStreamability(Object x) {
-        this.advancedOptions.strictStreamability = x;
+        this.advancedOptions.strictStreamability = x
     }
 
     void streamingFallback(Object x) {
-        this.advancedOptions.streamingFallback = x;
+        this.advancedOptions.streamingFallback = x
     }
 
     void stripWhitespace(Object x) {
-        this.advancedOptions['strip-whitespace'] = x;
+        this.advancedOptions['strip-whitespace'] = x
     }
 
     void styleParserClass(Object x) {
-        this.advancedOptions.styleParserClass = x;
+        this.advancedOptions.styleParserClass = x
     }
 
     void suppressEvaluationExpiryWarning(Object x) {
-        this.advancedOptions.suppressEvaluationExpiryWarning = x;
+        this.advancedOptions.suppressEvaluationExpiryWarning = x
     }
 
     void suppressXPathWarnings(Object x) {
-        this.advancedOptions.suppressXPathWarnings = x;
+        this.advancedOptions.suppressXPathWarnings = x
     }
 
     void suppressXsltNamespaceCheck(Object x) {
-        this.advancedOptions.suppressXsltNamespaceCheck = x;
+        this.advancedOptions.suppressXsltNamespaceCheck = x
     }
 
     void thresholdForCompilingTypes(Object x) {
-        this.advancedOptions.thresholdForCompilingTypes = x;
+        this.advancedOptions.thresholdForCompilingTypes = x
     }
 
     void timing(Object x) {
-        this.advancedOptions.timing = x;
+        this.advancedOptions.timing = x
     }
 
     void traceExternalFunctions(Object x) {
-        this.advancedOptions['trace-external-functions'] = x;
+        this.advancedOptions['trace-external-functions'] = x
     }
 
     void traceListener(Object x) {
-        this.advancedOptions.traceListener = x;
+        this.advancedOptions.traceListener = x
     }
 
     void traceListenerClass(Object x) {
-        this.advancedOptions.traceListenerClass = x;
+        this.advancedOptions.traceListenerClass = x
     }
 
     void traceListenerOutputFile(Object x) {
-        this.advancedOptions.traceListenerOutputFile = x;
+        this.advancedOptions.traceListenerOutputFile = x
     }
 
     void traceOptimizerDecisions(Object x) {
-        this.advancedOptions['trace-optimizer-decisions'] = x;
+        this.advancedOptions['trace-optimizer-decisions'] = x
     }
 
     void treeModel(Object x) {
-        this.advancedOptions.treeModel = x;
+        this.advancedOptions.treeModel = x
     }
 
     void treeModelName(Object x) {
-        this.advancedOptions.treeModelName = x;
+        this.advancedOptions.treeModelName = x
     }
 
     void unparsedTextURIResolver(Object x) {
-        this.advancedOptions.unparsedTextURIResolver = x;
+        this.advancedOptions.unparsedTextURIResolver = x
     }
 
     void unparsedTextURIResolverClass(Object x) {
-        this.advancedOptions.unparsedTextURIResolverClass = x;
+        this.advancedOptions.unparsedTextURIResolverClass = x
     }
 
     void uriResolverClass(Object x) {
-        this.advancedOptions.uriResolverClass = x;
+        this.advancedOptions.uriResolverClass = x
     }
 
     void usePiDisableOutputEscaping(Object x) {
-        this.advancedOptions['use-pi-disable-output-escaping'] = x;
+        this.advancedOptions['use-pi-disable-output-escaping'] = x
     }
 
     void useTypedValueCache(Object x) {
-        this.advancedOptions['use-typed-value-cache'] = x;
+        this.advancedOptions['use-typed-value-cache'] = x
     }
 
     void useXsiSchemaLocation(Object x) {
-        this.advancedOptions.useXsiSchemaLocation = x;
+        this.advancedOptions.useXsiSchemaLocation = x
     }
 
     void validationComments(Object x) {
-        this.advancedOptions['validation-comments'] = x;
+        this.advancedOptions['validation-comments'] = x
     }
 
     void validationWarnings(Object x) {
-        this.advancedOptions['validation-warnings'] = x;
+        this.advancedOptions['validation-warnings'] = x
     }
 
     void versionWarning(Object x) {
-        this.advancedOptions['version-warning'] = x;
+        this.advancedOptions['version-warning'] = x
     }
 
     void xincludeAware(Object x) {
-        this.advancedOptions['xinclude-aware'] = x;
+        this.advancedOptions['xinclude-aware'] = x
     }
 
     void xmlVersion(Object x) {
-        this.advancedOptions['xml-version'] = x;
+        this.advancedOptions['xml-version'] = x
     }
 
     void xqueryAllowUpdate(Object x) {
-        this.advancedOptions.xqueryAllowUpdate = x;
+        this.advancedOptions.xqueryAllowUpdate = x
     }
 
     void xqueryConstructionMode(Object x) {
-        this.advancedOptions.xqueryConstructionMode = x;
+        this.advancedOptions.xqueryConstructionMode = x
     }
 
     void xqueryDefaultElementNamespace(Object x) {
-        this.advancedOptions.xqueryDefaultElementNamespace = x;
+        this.advancedOptions.xqueryDefaultElementNamespace = x
     }
 
     void xqueryDefaultFunctionNamespace(Object x) {
-        this.advancedOptions.xqueryDefaultFunctionNamespace = x;
+        this.advancedOptions.xqueryDefaultFunctionNamespace = x
     }
 
     void xqueryEmptyLeast(Object x) {
-        this.advancedOptions.xqueryEmptyLeast = x;
+        this.advancedOptions.xqueryEmptyLeast = x
     }
 
     void xqueryInheritNamespaces(Object x) {
-        this.advancedOptions.xqueryInheritNamespaces = x;
+        this.advancedOptions.xqueryInheritNamespaces = x
     }
 
     void xqueryMultipleModuleImports(Object x) {
-        this.advancedOptions.xqueryMultipleModuleImports = x;
+        this.advancedOptions.xqueryMultipleModuleImports = x
     }
 
     void xqueryPreserveBoundarySpace(Object x) {
-        this.advancedOptions.xqueryPreserveBoundarySpace = x;
+        this.advancedOptions.xqueryPreserveBoundarySpace = x
     }
 
     void xqueryPreserveNamespaces(Object x) {
-        this.advancedOptions.xqueryPreserveNamespaces = x;
+        this.advancedOptions.xqueryPreserveNamespaces = x
     }
 
     void xqueryRequiredContextItemType(Object x) {
-        this.advancedOptions.xqueryRequiredContextItemType = x;
+        this.advancedOptions.xqueryRequiredContextItemType = x
     }
 
     void xquerySchemaAware(Object x) {
-        this.advancedOptions.xquerySchemaAware = x;
+        this.advancedOptions.xquerySchemaAware = x
     }
 
     void xqueryStaticErrorListenerClass(Object x) {
-        this.advancedOptions.xqueryStaticErrorListenerClass = x;
+        this.advancedOptions.xqueryStaticErrorListenerClass = x
     }
 
     void xqueryVersion(Object x) {
-        this.advancedOptions.xqueryVersion = x;
+        this.advancedOptions.xqueryVersion = x
     }
 
     void xsdVersion(Object x) {
-        this.advancedOptions['xsd-version'] = x;
+        this.advancedOptions['xsd-version'] = x
     }
 
     void enableAssertions(Object x) {
-        this.advancedOptions.enableAssertions = x;
+        this.advancedOptions.enableAssertions = x
     }
 
     void xsltSchemaAware(Object x) {
-        this.advancedOptions.xsltSchemaAware = x;
+        this.advancedOptions.xsltSchemaAware = x
     }
 
     void stylesheetErrorListener(Object x) {
-        this.advancedOptions.stylesheetErrorListener = x;
+        this.advancedOptions.stylesheetErrorListener = x
     }
 
     void stylesheetURIResolver(Object x) {
-        this.advancedOptions.stylesheetURIResolver = x;
+        this.advancedOptions.stylesheetURIResolver = x
     }
 
     void xsltVersion(Object x) {
-        this.advancedOptions.xsltVersion = x;
+        this.advancedOptions.xsltVersion = x
     }
 
     // END ADVANCED OPTIONS
@@ -651,7 +663,7 @@ class SaxonXsltTask extends DefaultTask {
     protected URI resolveUri(String path) {
         URI uri = new URI(path)
 
-        if (this.options.catalog) {
+        if (this.catalogFile) {
             String resolved = xmlCatalog.resolveURI(path)
             resolved ? new URI(resolved) : uri
         } else {
@@ -677,14 +689,14 @@ class SaxonXsltTask extends DefaultTask {
               }
             }
           } catch (FileNotFoundException ex) {
-            // nevermind
+            logger.debug("Could not check for all imported stylesheet.", ex)
           } catch (Exception ex) {
             logger.warn("Failed to parse: ${stylesheet}")
             logger.warn("  ${ex.getMessage()}")
           }
-
-          return project.files(newCollection)
         }
+
+        return project.files(newCollection)
     }
 
     String getOutputFileName(File file) {
@@ -706,7 +718,7 @@ class SaxonXsltTask extends DefaultTask {
     protected File getOutputFile(File file) {
         Path filePath = file.toPath()
         Path rootPath = project.rootDir.toPath()
-        Path outputPath = project.file(this.options.output).toPath()
+        Path outputPath = project.file(this.outputDir).toPath()
 
         if (this.pluginOptions.outputDirectoryLayout == 'nested' && filePath.startsWith(rootPath) && outputPath.startsWith(rootPath)) {
             Path dir = rootPath.relativize(filePath).parent
@@ -725,33 +737,63 @@ class SaxonXsltTask extends DefaultTask {
             //
             // Anyway, this approach likely covers a large chunk of how people
             // would conceivably use this feature anyway.
-        } else if (project.files(this.options.input).size() == 1 && project.buildDir.getAbsolutePath() != this.options.output.getAbsolutePath()) {
-            this.options.output
+        } else if (project.files(this.inputFiles).size() == 1 && project.buildDir.getAbsolutePath() != this.outputDir.getAbsolutePath()) {
+            this.outputDir
         } else {
-            new File(this.options.output, getOutputFileName(file))
-        }
-    }
-
-    @OutputFiles
-    FileCollection getOutputFiles() {
-        if (this.options.input != null) {
-            project.files(project.files(this.options.input).collect { getOutputFile(it) })
-        } else {
-            project.files(this.options.output)
+            new File(this.outputDir, getOutputFileName(file))
         }
     }
 
     @InputFiles
     @SkipWhenEmpty
-    FileCollection getInputFiles() {
-        FileCollection stylesheets = project.files() + getIncludedStylesheets(this.options.stylesheet)
+    @PathSensitive(PathSensitivity.RELATIVE)
+    FileCollection getInputStylesheets() {
+        getIncludedStylesheets(this.stylesheetFile)
+    }
 
-        if (this.options.input != null) {
-            project.files(this.options.input) + stylesheets
+    @Input
+    Map<String, String> getStylesheetParams(){
+        stylesheetParams.asImmutable()
+    }
+
+    @InputFiles
+    @SkipWhenEmpty
+    @PathSensitive(PathSensitivity.RELATIVE)
+    FileCollection getInputFiles(){
+        inputFiles ? project.files(this.inputFiles) : project.files()
+    }
+
+    @Input
+    Map<String, Object> getOptions(){
+        options.asImmutable()
+    }
+
+    @Input
+    Map<String,Object> getPluginOptions(){
+        pluginOptions.asImmutable()
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @Optional
+    File getCatalogFile(){
+        catalogFile
+    }
+
+    @Input
+    Map<String, Object> getAdvancedOptions(){
+        advancedOptions.asImmutable()
+    }
+
+    @OutputFiles
+    FileCollection getOutputFiles() {
+        if (this.inputFiles != null) {
+            project.files(project.files(this.inputFiles).collect { getOutputFile(it) })
         } else {
-            stylesheets
+            project.files(this.outputDir)
         }
     }
+
 
     // Turn a key-value pair into a Saxon command line argument.
     //
@@ -789,11 +831,11 @@ class SaxonXsltTask extends DefaultTask {
     // and output.
     @Internal
     protected List<String> getCommonArguments() {
-        Map<String, String> commonOptions = this.options.findAll { name, value ->
-            !['input', 'output'].contains(name)
-        }.asImmutable()
-
-        (commonOptions.inject(this.defaultArguments) { arguments, entry ->
+        def fileArguments = [makeSingleHyphenArgument(Argument.MAPPING.stylesheet, stylesheetFile)]
+        if(catalogFile) {
+            fileArguments.add(makeSingleHyphenArgument(Argument.MAPPING.catalog, catalogFile))
+        }
+        (options.inject(DEFAULT_ARGUMENTS) { arguments, entry ->
             String defaultArgument = Argument.MAPPING[entry.key]
 
             if (defaultArgument == null) {
@@ -805,7 +847,7 @@ class SaxonXsltTask extends DefaultTask {
             arguments + makeSingleHyphenArgument(defaultArgument, entry.value)
         } + advancedOptions.collect {
             makeDoubleHyphenArgument(it.key, it.value)
-        }).asImmutable()
+        } + fileArguments).asImmutable()
     }
 
     protected List<String> getFileSpecificArguments(File file) {
@@ -819,13 +861,13 @@ class SaxonXsltTask extends DefaultTask {
     @TaskAction
     void run() {
         WorkQueue workQueue = workerExecutor.classLoaderIsolation() {
-            it.getClasspath().from(this.classpath);
-        };
+            it.getClasspath().from(this.classpath)
+        }
 
         List<String> commonArguments = getCommonArguments() + getStylesheetParameters()
 
-        if (this.options.input != null) {
-            project.files(this.options.input).each {
+        if (this.inputFiles != null) {
+            project.files(this.inputFiles).each {
                 List<String> arguments = getFileSpecificArguments(it) + commonArguments
 
                 workQueue.submit(XsltTransformation) {
@@ -833,7 +875,7 @@ class SaxonXsltTask extends DefaultTask {
                 }
             }
         } else {
-            String output = this.options.output.getPath()
+            String output = this.outputDir.getPath()
             List<String> arguments = commonArguments + [makeSingleHyphenArgument(Argument.MAPPING.output, output)]
 
             workQueue.submit(XsltTransformation) {

--- a/src/main/resources/META-INF/gradle-plugins/com.github.eerohele.saxon-gradle.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.github.eerohele.saxon-gradle.properties
@@ -1,1 +1,0 @@
-implementation-class = com.github.eerohele.SaxonPlugin

--- a/src/main/resources/configuration.xml
+++ b/src/main/resources/configuration.xml
@@ -1,6 +1,0 @@
-<configuration xmlns="http://saxon.sf.net/ns/configuration" edition="HE">
-  <xslt
-     version="3.0"
-     >
-  </xslt>
-</configuration>

--- a/src/test/groovy/com/github/eerohele/SaxonXsltTaskSpec.groovy
+++ b/src/test/groovy/com/github/eerohele/SaxonXsltTaskSpec.groovy
@@ -59,7 +59,7 @@ class SaxonXsltTaskSpec extends Specification {
         GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
                 .withPluginClasspath()
-                .withArguments(':xslt')
+                .withArguments(':xslt', '--stacktrace', '--warning-mode=fail')
                 .forwardOutput()
                 .build()
     }
@@ -501,7 +501,7 @@ class SaxonXsltTaskSpec extends Specification {
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
                 .withPluginClasspath()
-                .withArguments(':xslt')
+                .withArguments(':xslt', '--stacktrace', '--warning-mode=fail')
                 .forwardOutput()
                 .build()
 


### PR DESCRIPTION
- remove file based properties from options map and place them in dedicated variables (adding `@InputFile` `@PathSensitive` annotations)
-- input
-- catalog
-- stylesheet
-- output
- expose other properties as `@Input` properties
- cleanup redundant semicolons

this should fix: #30 and #29 